### PR TITLE
Add Mo Stake to the list

### DIFF
--- a/data/configuration.json
+++ b/data/configuration.json
@@ -75,6 +75,7 @@
     "emoneyvaloper1zca529sff7x4sm2t06x4a5stl7ug0xqxg4wgd9",
     "emoneyvaloper1zgv6tqess9q6y4cj28ldpjllrqlyzqqh80fpgu",
     "emoneyvaloper1zqw523wa8vgflc83jqjd3g7h6p9rj0qyngs522",
-    "emoneyvaloper1zxxd24h25phc744tjgtatafh05vtw6rve4xmwe"
+    "emoneyvaloper1zxxd24h25phc744tjgtatafh05vtw6rve4xmwe",
+    "emoneyvaloper1kzt0xm7r9xswucdqlhapg0qtl4eglcmw63sy23"
   ]
 }


### PR DESCRIPTION
Mo Stake is running its e-money validator in a tier-1 hosting provider using a 6 core (dedicated), 16 GB VPS with redundant 240 GB SSDs. Mo Stake also runs a private fleet of Helium Network validators since mainnet validator launch (July 2021) as well as actively participated that testnet in Q1 2021. Mo's lead engineer has been in the IT industry for 15 years.