### PR TITLE
Add qf3l3k validator

### DIFF
--- a/data/configuration.json
+++ b/data/configuration.json
@@ -77,6 +77,7 @@
     "emoneyvaloper1zqw523wa8vgflc83jqjd3g7h6p9rj0qyngs522",
     "emoneyvaloper1zxxd24h25phc744tjgtatafh05vtw6rve4xmwe",
     "emoneyvaloper1tpu0vxh520g4axd00nzdypggnz26z9atfjr3mt",
-    "emoneyvaloper17kts3kupmmgvhxsfhak86g0gwqy87lf4dptnpx"
+    "emoneyvaloper17kts3kupmmgvhxsfhak86g0gwqy87lf4dptnpx",
+    "emoneyvaloper14ltn0tu3vjfgflpkmr559k5wgvyumpq6720cd0"
   ]
 }


### PR DESCRIPTION
I'm operating validators for few Cosmos-based chains: Sentinel, Fetch.ai, Sifchain, Rizon, BitSong, Kava, Medibloc, KiChain and most recently with very small stake MicroTick and Juno. I'm genesis validator in Sentinel and Rizon. In KiChain and Rizon I got rewards for testnet participation, which included relayer setup, tx-spamming, etc.
At the moment also providing on-going testnet infrastructure for Sentinel, Fetch.ai, KiChain for development and experimentation purposes.
As infrastructure I use VPS servers and physical boxes across 3 providers. Each validator has it's backup (fullnode) histed with different provider than main validator. 
Switchover in case of failure is manual to avoid any issues with double-sign. All servers are monitored with Prometheus/Grafana stack to track servers health.
Validator keys are backed up in secure location not exposed directly to Internet.