### PR TITLE
Add freak12techno validator to whitelist

### DIFF
--- a/data/configuration.json
+++ b/data/configuration.json
@@ -87,6 +87,7 @@
     "emoneyvaloper1mk6s3r0d88j67zvp3rs9eum9feumeh63tatsgx",
     "emoneyvaloper1j2hkysjqcamdn4rsq8g8pvpkdmmxkt54u3gkdr",
     "emoneyvaloper1xwazl8ftks4gn00y5x3c47auquc62ssudg660q",
-    "emoneyvaloper1653dpq27fr8rykpg4zmsqmmvtxhhcwxvvm9p9d"
+    "emoneyvaloper1653dpq27fr8rykpg4zmsqmmvtxhhcwxvvm9p9d",
+    "emoneyvaloper1jk4n79c5gv36972ptnly3rvx5nvn3hl3hgly9g"
   ]
 }


### PR DESCRIPTION
Full disclosure: I am also of the people maintaining SOLAR Validator. SOLAR Validator is a validator bound to a legal entity in Estonia, having its own infrastructure. This is my personal one, hosted in another place and not connected to SOLAR Validator in any other way. I've discussed it with @haasted beforehand and he says it's okay.

Anyway, answering any potential forthcoming questions:
1) I have a website describing some of the details of the validators I'm having: https://freak12techno.github.io/validators/
2) I also maintain SOLAR Validator on e-Money chain and 5 more other chains (Sentinel, Persistence, Osmosis, Juno, Desmos)
3) I am a sole person responsible for this one and as stated above I have experience with setting up and operating validators
4) All transactions are signed using Ledger Nano S (except for the one used to create a validator)
5) I use Prometheus + Grafana for monitoring 24/7 as well as some of the custom tools I've developed for observability and monitoring (check out https://github.com/solarlabsteam and my website for that)
6) In the nearest future I plan to move to a bare-metal server in a data center in my city, mostly to be able to use HSM (I also have experience with operating it)
7) A grain of salt: for now the node is hosted at a remote datacenter at a dedicated server. This is the first thing I plan to fix this by buying a bare-metal server and hosting it in a datacenter, then adding a HSM for that. For now I've spent ~3000$ on buying NGMs for staying in the active set and meeting the minimal requirements, so I don't have a lot of money left to buy this right now :( but definitely plan to do so in the future

Hope this would be sufficient, if not I'm open to any questions. Cheers!