### PR TITLE
Citadel.one delegation programm

### DIFF
--- a/data/configuration.json
+++ b/data/configuration.json
@@ -97,6 +97,7 @@
     "emoneyvaloper1zgv6tqess9q6y4cj28ldpjllrqlyzqqh80fpgu",
     "emoneyvaloper1zgy2c2adtvmgneuj0f599n7ykht3tdr8sq7g0t",
     "emoneyvaloper1zqw523wa8vgflc83jqjd3g7h6p9rj0qyngs522",
-    "emoneyvaloper1zxxd24h25phc744tjgtatafh05vtw6rve4xmwe"
+    "emoneyvaloper1zxxd24h25phc744tjgtatafh05vtw6rve4xmwe",
+    "emoneyvaloper19aas63km0rq96dtuuvjkn76nyyj67qre477gt3"
   ]
 }


### PR DESCRIPTION
Citadel.one started its validator journey in 2018 and today we already run active validator nodes in more than 35 networks. 
Apart from the extensive Validator universe, we develop a multifunctional non-custodial platform for all things crypto including storage, staking, analysis and asset-management.

The analytical dashboard provides relevant information on wallets’ balances and networks’ main metrics. You can claim and track your staking rewards instantly. 

In addition to network rewards, our users get XCT tokens for delegating crypto assets with our nodes. Then, by staking XCT they become Citadel.one DAO governance members.

Citadel.one aims to be an all-in-one platform; we plan to support networks’ core functionality and provide further use-cases for interactions with integrated assets.

For the technical part of our validator nodes we mostly use cloud providers. We monitor our nodes using zabbix and grafana/telegraf/prometheus/alertmanager stack with alerting to telegram to be always aware of any problems that might happen, making regular automated backups and using sentries. 