### PR TITLE
Added Okitoo Validator in configuration.json

### DIFF
--- a/data/configuration.json
+++ b/data/configuration.json
@@ -97,6 +97,7 @@
     "emoneyvaloper1zgv6tqess9q6y4cj28ldpjllrqlyzqqh80fpgu",
     "emoneyvaloper1zgy2c2adtvmgneuj0f599n7ykht3tdr8sq7g0t",
     "emoneyvaloper1zqw523wa8vgflc83jqjd3g7h6p9rj0qyngs522",
-    "emoneyvaloper1zxxd24h25phc744tjgtatafh05vtw6rve4xmwe"
+    "emoneyvaloper1zxxd24h25phc744tjgtatafh05vtw6rve4xmwe",
+    "emoneyvaloper1ef0u9vkwawct6vgv000m3gzwjkk30pkc8uf48e"
   ]
 }


### PR DESCRIPTION
We have a validator on Nomic and Sentinel
https://www.mintscan.io/sentinel/validators/sentvaloper16yg44hae44lcdexmmk7wpaphny0ahmqf6zevq5
Node name: Okitoo Networks
Node Address: nomic192xgtwh9r6z77snecxtnhkc78xcwzfuq5knlyw

We are a startup company that develops apps on the blockchain.
At this moment we are building a dvpn app on the Sentinel blockchain.
Our app is already in playstore beta : https://vpn.okitoo.net/

We have a history in developing the game HackersOnline.
The multiplayer game for android hackerz online was a massive succes in it's time. Due to personal issues in life we had to halt the development of the game and as a result it died out.

https://www.facebook.com/hackerzOnline/
JoeyCheapService : https://t.me/joey19944
Okitoo Github : https://github.com/Okitoo
Twitter : https://twitter.com/okitoo_net

The specification of my Validator node is : 
Intel Xeon E3-1275V6  PLUSNIC 1 Gbit
- Intel I219-LM
HDD2x SSD M.2 NVMe 512 GB
RAM4x RAM 16384 MB DDR4 ECC


The specification of my first Sentry node is : Intel Xeon E3-1275v5  PLUSNIC 1 Gbit
- Intel I219-LM
HDD2x SSD M.2 NVMe 512 GB
RAM4x RAM 16384 MB DDR4 ECC


The specification of my second Sentry node is : Intel Core i7-3930  PLUSNIC 1 Gbit
- Intel 82579LM
HDD2x SSD SATA 512 GB

RAM8x RAM 8192 MB DDR3

The validator node is set up using the Sentry architecture and is totally shielded off from the internet. https://forum.cosmos.network/t/sentry-node-architecture-overview/454
 The servers are hosted in a Datacenter confirm all requirements of a safe and secure Datacenter. : https://www.hetzner.com/unternehmen/rechenzentrum

Each node is hosted in a different datacenter : Nuremburg , Falkenstein , Helsinki.