### PR TITLE
 Add new validator PowerStaking

### DIFF
--- a/data/configuration.json
+++ b/data/configuration.json
@@ -104,6 +104,7 @@
     "emoneyvaloper1w8az00hy6p5gdq873sw9rvvp9whdvd6swsgmh3",
     "emoneyvaloper1vnwe84z2ahuy8ua04a0m2yvj5krtxyd576efh0",
     "emoneyvaloper1qmc4pwtsaqzhp7tp9rh5xtcgf0vk6fp9jxmpd6",
-    "emoneyvaloper1gzyn2r8atqwntugn93jxlmn2hhmepglkztc237"
+    "emoneyvaloper1gzyn2r8atqwntugn93jxlmn2hhmepglkztc237",
+    "emoneyvaloper18hvr75ntz8rgzfdmuhnf3eh78clt5909lfl3ws"
   ]
 }


### PR DESCRIPTION
I am part of a team of dedicated professionals DevOps and Developers engineers working to build the infrastructure for the future financial systems. The validator it's been up and running since 2 weeks now, with no problems https://bigdipper.live/emoney/validators/emoneyvaloper18hvr75ntz8rgzfdmuhnf3eh78clt5909lfl3ws

Other validators:
bitsong https://explorebitsong.com/bitsong/validators/bitsongvaloper1wcvhw2ts80ywk3avd9ad8qmrwaeqwmkpg2shxz I also have other validators for testnets, for example: agoric testnet https://devnet.explorer.agoric.net/agoric/staking/agoricvaloper1pn5fuga5sgy2n20f2purja8pgxdzrte5l3v8we

Infrastructure:
2x datacenter servers (for the moment), 16 core, 128GB ECC, 2x 4TB nmve raid 1, gigabit bandwith guaranteed

Monitoring:Grafana, custom tools for node health (sync status, block height, connected peers ...)

Contact:
Website https://powerstaking.tech/
Keybase https://keybase.io/crpnoob